### PR TITLE
v2 release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Leonid Emar-Kar
+Copyright (c) 2025 Leonid Emar-Kar
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # copy
 Simple copy module for go applications, which allows to create copies of files and folders.
 
+## Installation
+```bash
+go get github.com/emar-kar/copy/v2
+```
+
 ## Available options
 
-- `Force`: re-writes destination if it is already exists.
-- `ContentOnly`: copies only source folder content without creating root folder in destination.
-- `WithMove`: removes source after copying process is finished.
-- `WithBufferSize`: allows to set custom buffer size for file copy. If provided size <= 0, then default 4096 will be used.
-- `RevertOnErr`: removes destination file if there was an error during copy process.
-- `WithHash`: calculates hash of the copied files for client's use.
+- `WithBufferSize`: allows to set custom buffer size for file copy. If provided size <= 0, then default 65536 bytes will be used.
+- `WithExcludeFunc`: allows to set custom function to exclude paths.
+- `Force`: re-writes destination if it already exists.
+- `WithNoFollow`: creates symlinks instead of resolving paths.
 
 ### Paths processing
-If you need to copy file with the same name to destination, you need to add trailing slash at the destination path, since it will consider the last path element as the file name. The file name might be the same as the source file or a new custom one.
+If you need to copy file or folder with the same name as source in destination, just add trailing slash at the destination path, since it will consider the last path element as the file name.

--- a/copy_test.go
+++ b/copy_test.go
@@ -1,0 +1,315 @@
+package copy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/emar-kar/copy/v2/internal/utils"
+)
+
+var (
+	testData = []byte("test file data")
+
+	folders = []string{
+		"folder1", "folder1/folder2", "folder1/folder2_1", "folder1/folder2/folder3",
+	}
+	files    = []string{"file1", "folder1/folder2/file2", "folder1/folder2/folder3/file3"}
+	symlinks = []string{"folder1/folder2:folder2", "folder1/folder2/folder3/file3:file3"}
+)
+
+type testCase struct {
+	name     string
+	src, dst string
+	options  []optFunc
+	context  func() context.Context
+	preFunc  func() error
+	resFunc  func(error) error
+	postFunc func() error
+}
+
+func createSourceTree() (string, error) {
+	temp, err := os.MkdirTemp("", "")
+	if err != nil {
+		return "", err
+	}
+
+	for _, f := range folders {
+		if err := os.MkdirAll(path.Join(temp, f), 0o755); err != nil {
+			return "", err
+		}
+	}
+
+	for _, f := range files {
+		p := path.Join(temp, f)
+		if err := os.WriteFile(p, testData, 0o755); err != nil {
+			return "", err
+		}
+	}
+
+	for _, s := range symlinks {
+		sp := strings.Split(s, ":")
+		src, dst := path.Join(temp, sp[0]), path.Join(temp, sp[1])
+		if err := os.Symlink(src, dst); err != nil {
+			return "", err
+		}
+	}
+
+	return temp, nil
+}
+
+func TestCopy(t *testing.T) {
+	src, err := createSourceTree()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dst := path.Join(os.TempDir(), "destination")
+
+	defer func() {
+		os.RemoveAll(src)
+		os.RemoveAll(dst)
+	}()
+
+	tests := []testCase{
+		{
+			"FileCopy",
+			path.Join(src, "file1"),
+			dst + "/",
+			[]optFunc{WithBufferSize(-1), Force},
+			func() context.Context { return t.Context() },
+			func() error {
+				if err := os.MkdirAll(dst, 0o755); err != nil {
+					return err
+				}
+
+				return os.WriteFile(
+					path.Join(dst, "file1"), []byte("wrong data"), 0o755,
+				)
+			},
+			func(_ error) error {
+				p := path.Join(dst, "file1")
+				if _, err := os.Stat(p); errors.Is(err, fs.ErrNotExist) {
+					return err
+				}
+
+				data, err := os.ReadFile(p)
+				if err != nil {
+					return err
+				}
+
+				if !bytes.Equal(testData, data) {
+					return fmt.Errorf(
+						"byte slices are not equal: want: %v; got: %v", testData, data,
+					)
+				}
+
+				return nil
+			},
+			func() error { return nil },
+		},
+		{
+			"TreeCopy",
+			src,
+			dst,
+			[]optFunc{WithBufferSize(1024)},
+			func() context.Context { return t.Context() },
+			func() error { return nil },
+			func(cErr error) error {
+				if cErr != nil {
+					return cErr
+				}
+
+				for _, f := range append(folders, files...) {
+					if _, err := os.Stat(path.Join(dst, f)); errors.Is(err, fs.ErrNotExist) {
+						return err
+					}
+				}
+
+				for _, s := range symlinks {
+					sp := strings.Split(s, ":")
+					_, link, err := utils.ResolvePath(path.Join(dst, sp[1]))
+					if err != nil {
+						return err
+					}
+
+					if link {
+						return fmt.Errorf("%s: is a symlink", path.Join(dst, s))
+					}
+				}
+
+				return nil
+			},
+			func() error { return nil },
+		},
+		{
+			"FileCopySymlink",
+			path.Join(src, "file3"),
+			dst + "/",
+			[]optFunc{WithNoFollow},
+			func() context.Context { return t.Context() },
+			func() error { return nil },
+			func(_ error) error {
+				_, link, err := utils.ResolvePath(path.Join(dst, "file3"))
+				if err != nil {
+					return err
+				}
+
+				if !link {
+					return fmt.Errorf("%s: is not a symlink", path.Join(dst, "file3"))
+				}
+
+				return nil
+			},
+			func() error { return nil },
+		},
+		{
+			"FileNoCopyExclude",
+			path.Join(src, "file1"),
+			dst + "/",
+			[]optFunc{WithExcludeFunc(func(s string) bool { return path.Base(s) == "file1" })},
+			func() context.Context { return t.Context() },
+			func() error { return nil },
+			func(cErr error) error {
+				if cErr != nil {
+					return cErr
+				}
+
+				if _, err := os.Stat(
+					path.Join(dst, "file1"),
+				); !errors.Is(err, fs.ErrNotExist) {
+					return fmt.Errorf("%s: %w", path.Join(dst, "file1"), fs.ErrExist)
+				}
+
+				return nil
+			},
+			func() error { return nil },
+		},
+		{
+			"CopyTreeNoFollow",
+			src,
+			dst,
+			[]optFunc{
+				WithNoFollow,
+				WithExcludeFunc(func(s string) bool {
+					return strings.Contains(s, "folder3")
+				}),
+			},
+			func() context.Context { return t.Context() },
+			func() error { return nil },
+			func(cErr error) error {
+				if cErr != nil {
+					return cErr
+				}
+
+				for _, f := range append(folders, files...) {
+					if strings.Contains(f, "folder3") {
+						continue
+					}
+
+					if _, err := os.Stat(path.Join(dst, f)); errors.Is(err, fs.ErrNotExist) {
+						return err
+					}
+				}
+
+				for _, s := range symlinks {
+					sp := strings.Split(s, ":")
+
+					if strings.Contains(sp[0], "folder3") {
+						continue
+					}
+
+					res, link, err := utils.ResolvePath(path.Join(dst, sp[1]))
+					if err != nil {
+						return err
+					}
+
+					if !link {
+						return fmt.Errorf("%s: is not a symlink", path.Join(dst, sp[1]))
+					}
+
+					p, _, err := utils.ResolvePath(path.Join(src, sp[1]))
+					if err != nil {
+						return err
+					}
+
+					if res != p {
+						return fmt.Errorf(
+							"%s: wrong symlink: want: %s; got: %s",
+							path.Join(dst, sp[1]), p, res,
+						)
+					}
+				}
+
+				return nil
+			},
+			func() error { return nil },
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.preFunc(); err != nil {
+				t.Errorf("%s: preFunc error: %s", tc.name, err)
+			}
+
+			if err := tc.resFunc(Copy(
+				tc.context(),
+				tc.src,
+				tc.dst,
+				tc.options...,
+			)); err != nil {
+				t.Errorf("%s: error: %s", tc.name, err)
+			}
+
+			if err := tc.postFunc(); err != nil {
+				t.Errorf("%s: postFunc error: %s", tc.name, err)
+			}
+
+			if err := os.RemoveAll(dst); err != nil {
+				t.Errorf("%s: cleanup error: %s", tc.name, err)
+			}
+		})
+	}
+}
+
+func TestCopySameFile(t *testing.T) {
+	temp, err := os.CreateTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(temp.Name())
+
+	if err := Copy(t.Context(), temp.Name(), temp.Name()); err == nil {
+		t.Fatal("error was expected, but copy was successful")
+	} else if !errors.Is(err, ErrSame) {
+		t.Fatalf("unexpected error: want %s; got: %s", ErrSame, err)
+	}
+}
+
+func TestCopyAlreadyExists(t *testing.T) {
+	src, err := os.CreateTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(src.Name())
+
+	dst, err := os.CreateTemp("", "")
+	if err != nil {
+		os.RemoveAll(src.Name())
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dst.Name())
+
+	if err := Copy(t.Context(), src.Name(), dst.Name()); err == nil {
+		t.Fatal("error was expected, but copy was successful")
+	} else if !errors.Is(err, fs.ErrExist) {
+		t.Fatalf("unexpected error: want %s; got: %s", fs.ErrExist, err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,19 +1,4 @@
-module github.com/emar-kar/copy
+module github.com/emar-kar/copy/v2
 
-go 1.21
+go 1.24
 
-retract (
-    v1.3.0-ec98d0b5
-    v1.2.0-a4898caa
-    v1.2.0-314d0ebd9f0600b1baa91c50bd4060cad63d7406
-    v1.1.0
-    v1.1.0-alpha.8
-    v1.1.0-alpha.7
-    v1.1.0-alpha.6
-    v1.1.0-alpha.5
-    v1.1.0-alpha.4
-    v1.1.0-alpha.3.1
-    v1.1.0-alpha.3
-    v1.1.0-alpha.2
-    v1.1.0-alpha.1
-)

--- a/internal/contextio/contextio.go
+++ b/internal/contextio/contextio.go
@@ -1,0 +1,40 @@
+package contextio
+
+import (
+	"context"
+	"io"
+)
+
+type reader struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+// Reader returns [io.Reader] implementation wrapped with [context.Context].
+// Its Read method returns a context error on call if it is not nil.
+func Reader(ctx context.Context, r io.Reader) *reader { return &reader{ctx, r} }
+
+func (r *reader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+
+	return r.r.Read(p)
+}
+
+type writer struct {
+	ctx context.Context
+	w   io.Writer
+}
+
+// Writer returns [io.Writer] implementation wrapped with [context.Context].
+// Its Write method returns a context error on call if it is not nil.
+func Writer(ctx context.Context, w io.Writer) *writer { return &writer{ctx, w} }
+
+func (w *writer) Write(p []byte) (int, error) {
+	if err := w.ctx.Err(); err != nil {
+		return 0, err
+	}
+
+	return w.w.Write(p)
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// ResolvePath resolves symlinks and relative paths.
+func ResolvePath(p string) (string, bool, error) {
+	info, err := os.Lstat(p)
+	if err != nil {
+		return "", false, err
+	}
+
+	var isLink bool
+
+	if info.Mode()&os.ModeSymlink == os.ModeSymlink {
+		isLink = true
+
+		if p, err = filepath.EvalSymlinks(p); err != nil {
+			return "", isLink, err
+		}
+	}
+
+	p, err = filepath.Abs(p)
+
+	return p, isLink, err
+}

--- a/options.go
+++ b/options.go
@@ -1,75 +1,47 @@
 package copy
 
-import "hash"
-
-const defaultBufferSize = 4096
-
-// options allows to configure Copy behavior.
-type options struct {
-	exclude     []string
-	hash        hash.Hash
-	bufSize     int
-	force       bool
-	contentOnly bool
-	move        bool
-	revert      bool
-	follow      bool
-}
-
-func defaultOptions() *options {
-	return &options{bufSize: defaultBufferSize}
-}
+const defaultBufSize = 64 * 1024
 
 type (
-	optFunc func(*options)
+	optFunc     func(*options)
+	excludeFunc func(string) bool
 
-	// Type to create custom slices of copy options.
-	Options []optFunc
+	options struct {
+		excludeFunc excludeFunc
+		bufSize     int
+		force       bool
+		noFollow    bool
+	}
 )
 
-// Force re-writes destination if it is already exists.
-func Force(o *options) { o.force = true }
-
-// ContentOnly copies only source folder content without creating
-// root folder in destination.
-func ContentOnly(o *options) { o.contentOnly = true }
-
-// FollowSymlink resolves source file path before copy, to follow symlink
-// if needed.
-func FollowSymlink(o *options) { o.follow = true }
-
-// WithMove removes source after copying process is finished.
-func WithMove(o *options) { o.move = true }
+func defaultOptions() *options {
+	return &options{
+		excludeFunc: func(_ string) bool { return false },
+		bufSize:     defaultBufSize,
+	}
+}
 
 // WithBufferSize allows to set custom buffer size for file copy.
-// If provided size <= 0, then default will be used.
-func WithBufferSize(size int) optFunc {
+// If provided size is <= 0, then default will be used.
+func WithBufferSize(i int) optFunc {
 	return func(o *options) {
-		if size <= 0 {
+		if i <= 0 {
 			return
 		}
 
-		o.bufSize = size
+		o.bufSize = i
 	}
 }
 
-// RevertOnErr removes destination file if there was an error during copy process.
-func RevertOnErr(o *options) { o.revert = true }
-
-// WithHash calculates hash of the copied file(s).
-//
-// Note: if hash is not nil, it guarantee the copied file(s) will be read.
-// Might increase total execution time.
-func WithHash(h hash.Hash) optFunc {
+// WithExcludeFunc allows to filter files and folders by path.
+func WithExcludeFunc(fn excludeFunc) optFunc {
 	return func(o *options) {
-		o.hash = h
+		o.excludeFunc = fn
 	}
 }
 
-// WithExclude excludes paths from copy which includes one of the given
-// strings.
-func WithExclude(s ...string) optFunc {
-	return func(o *options) {
-		o.exclude = append(o.exclude, s...)
-	}
-}
+// Force rewrites destination if it already exists.
+func Force(o *options) { o.force = true }
+
+// WithNoFollow creates symlinks instead of resolving path and copying the contents.
+func WithNoFollow(o *options) { o.noFollow = true }


### PR DESCRIPTION
* reworked copy processes to simplify the algorithm, increase stability and speed of the process
* add tests
* `contentOnly` option was deprecated, folders now follow the same trailing slash rule as files
* `exclude` option was replaced with more flexible func representation instead of a slice
* `hash` option was deprecated without replace
* `move` option was deprecated, since symlink support was upgraded, it hardens the decision making on correct removal, moved to users space
* `revert` option was deprecated, after some edge cases investigation, it hardens the algorithm in cases like, when you need to copy content to existing folder and on revert this folder could be removed completely, since there is no track of copied filed
* `follow` option has become default behavior after symlink support update
* `noFollow` option was added, to create symlinks instead of resolving paths